### PR TITLE
Handle json parsing errors

### DIFF
--- a/src/DocumentStatus.php
+++ b/src/DocumentStatus.php
@@ -6,6 +6,8 @@
 
 namespace DeepL;
 
+use JsonException;
+
 /**
  * Status of a document translation request.
  */
@@ -36,9 +38,17 @@ class DocumentStatus
      */
     public $errorMessage;
 
+    /**
+     * @throws InvalidContentException
+     */
     public function __construct(string $content)
     {
-        $json = json_decode($content, true);
+        try {
+            $json = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
+
         $this->status = $json['status'];
         $this->secondsRemaining = $json['seconds_remaining'] ?? null;
         $this->billedCharacters = $json['billed_characters'] ?? null;

--- a/src/GlossaryInfo.php
+++ b/src/GlossaryInfo.php
@@ -7,6 +7,7 @@
 namespace DeepL;
 
 use DateTime;
+use JsonException;
 
 /**
  * Information about a glossary, excluding the entry list.
@@ -52,15 +53,31 @@ class GlossaryInfo
         $this->entryCount = $entryCount;
     }
 
+    /**
+     * @throws InvalidContentException
+     */
     public static function parse(string $content): GlossaryInfo
     {
-        $object = json_decode($content, true);
+        try {
+            $object = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
+
         return self::parseJsonObject($object);
     }
 
+    /**
+     * @throws InvalidContentException
+     */
     public static function parseList(string $content): array
     {
-        $decoded = json_decode($content, true);
+        try {
+            $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
+
         $result = [];
         foreach ($decoded['glossaries'] as $object) {
             $result[] = self::parseJsonObject($object);

--- a/src/InvalidContentException.php
+++ b/src/InvalidContentException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DeepL;
+
+use JsonException;
+
+class InvalidContentException extends DeepLException
+{
+    public function __construct(JsonException $exception)
+    {
+        parent::__construct($exception->getMessage(), $exception->getCode(), $exception);
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -6,6 +6,8 @@
 
 namespace DeepL;
 
+use JsonException;
+
 /**
  * Wrapper for the DeepL API for language translation.
  * Create an instance of Translator to use the DeepL API.
@@ -109,7 +111,12 @@ class Translator
         $this->checkStatusCode($response);
         list(, $content) = $response;
 
-        $decoded = json_decode($content, true);
+        try {
+            $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
+
         $result = [];
         foreach ($decoded['supported_languages'] as $lang) {
             $sourceLang = $lang['source_lang'];
@@ -148,7 +155,12 @@ class Translator
         $this->checkStatusCode($response);
 
         list(, $content) = $response;
-        $decoded = json_decode($content, true);
+        try {
+            $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
+
         $textResults = [];
         foreach ($decoded['translations'] as $textResult) {
             $textField = $textResult['text'];
@@ -232,8 +244,12 @@ class Translator
         $this->checkStatusCode($response);
 
         list(, $content) = $response;
+        try {
+            $json = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
 
-        $json = json_decode($content, true);
         $documentId = $json['document_id'];
         $documentKey = $json['document_key'];
         return new DocumentHandle($documentId, $documentKey);
@@ -463,7 +479,12 @@ class Translator
         $this->checkStatusCode($response);
         list(, $content) = $response;
 
-        $decoded = json_decode($content, true);
+        try {
+            $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
+
         $result = [];
         foreach ($decoded as $lang) {
             $name = $lang['name'];
@@ -638,7 +659,7 @@ class Translator
 
         $message = '';
         try {
-            $json = json_decode($content, true);
+            $json = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
             if (isset($json['message'])) {
                 $message .= ", message: {$json['message']}";
             }

--- a/src/Usage.php
+++ b/src/Usage.php
@@ -6,6 +6,8 @@
 
 namespace DeepL;
 
+use JsonException;
+
 /**
  * Information about the API usage: how much has been translated in this billing period, and the
  * maximum allowable amount.
@@ -57,9 +59,16 @@ class Usage
         return $result;
     }
 
+    /**
+     * @throws InvalidContentException
+     */
     public function __construct(string $content)
     {
-        $json = json_decode($content, true);
+        try {
+            $json = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidContentException($exception);
+        }
 
         $this->character = $this->buildUsageDetail('character', $json);
         $this->document = $this->buildUsageDetail('document', $json);


### PR DESCRIPTION
Hi @daniel-jones-deepl,

We got some errors with this library when using `translateText` method
```
$response = $this->client->sendRequestWithBackoff(
            'POST',
            '/v2/translate',
            [HttpClient::OPTION_PARAMS => $params]
        );
        $this->checkStatusCode($response);

        list(, $content) = $response;
        $decoded = json_decode($content, true);
```
The content thrown by the API is not always a correct json, so json_decode fails and `$decoded` might be null ;
then it creates multiple warning/errors later.

I saw a lot of "unsafe" json_decode are made in this library. So I changed the behavior to this one:
- Adding the `JSON_THROW_ON_ERROR` flag to throw if the content is invalid
- Catching the exception in order to throw a DeeplException instead

This way we have invalid calls (throwing 400, 500, ...) and invalid responses (invalid json) are treated the same way with a DeeplException instead of some warning/null values/critical php errors.

Thanks for taking a look :)