### PR TITLE
Allow to configure connect timeout separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ The `Translator` constructor accepts configuration options as a second argument,
 for example:
 
 ```php
-$options = [ 'max_retries' => 5, 'timeout' => 10.0 ];
+$options = [ 'max_retries' => 5, 'connect_timeout' => 10.0 ];
 $translator = new \DeepL\Translator('YOUR_AUTH_KEY', $options);
 ```
 
@@ -405,7 +405,9 @@ Provide the options as an associative array with the following keys:
 - `max_retries`: the maximum number of failed HTTP requests to retry, per
     function call. By default, 5 retries are made. See
     [Request retries](#request-retries).
-- `timeout`: the number of seconds used as connection timeout for each
+- `connect_timeout`: the number of seconds used as connection timeout for each
+    HTTP request retry. The default value is `10.0` (10 seconds).
+- `exec_timeout`: the number of seconds used as curl execution timeout for each
     HTTP request retry. The default value is `10.0` (10 seconds).
 - `server_url`: `string` containing the URL of the DeepL API, can be overridden
     for example for testing purposes. By default, the URL is selected based on

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -54,7 +54,12 @@ class Translator
             $options[TranslatorOptions::HEADERS] ?? []
         );
 
-        $timeout = $options[TranslatorOptions::TIMEOUT] ?? TranslatorOptions::DEFAULT_TIMEOUT;
+        $connectTimeout = $options[TranslatorOptions::CONNECT_TIMEOUT]
+            ?? $options[TranslatorOptions::TIMEOUT]
+            ?? TranslatorOptions::DEFAULT_TIMEOUT;
+        $execTimeout = $options[TranslatorOptions::EXEC_TIMEOUT]
+            ?? $options[TranslatorOptions::TIMEOUT]
+            ?? TranslatorOptions::DEFAULT_TIMEOUT;
 
         $maxRetries = $options[TranslatorOptions::MAX_RETRIES] ?? TranslatorOptions::DEFAULT_MAX_RETRIES;
 
@@ -62,7 +67,7 @@ class Translator
 
         $proxy = $options[TranslatorOptions::PROXY] ?? null;
 
-        $this->client = new HttpClient($serverUrl, $headers, $timeout, $maxRetries, $logger, $proxy);
+        $this->client = new HttpClient($serverUrl, $headers, $connectTimeout, $execTimeout, $maxRetries, $logger, $proxy);
     }
 
     /**

--- a/src/TranslatorOptions.php
+++ b/src/TranslatorOptions.php
@@ -30,6 +30,19 @@ class TranslatorOptions
      * Connection timeout used for each HTTP request retry, as a float in seconds.
      * @see DEFAULT_TIMEOUT
      */
+    public const CONNECT_TIMEOUT = 'connect_timeout';
+
+    /**
+     * Curl execution timeout used for each HTTP request retry, as a float in seconds.
+     * @see DEFAULT_TIMEOUT
+     */
+    public const EXEC_TIMEOUT = 'exec_timeout';
+
+    /**
+     * Timeout used for each HTTP request retry (both connection and execution), as a float in seconds.
+     * @deprecated in favor of self::CONNECT_TIMEOUT and self::EXEC_TIMEOUT
+     * @see DEFAULT_TIMEOUT
+     */
     public const TIMEOUT = 'timeout';
 
     /**


### PR DESCRIPTION
Hi @daniel-jones-deepl,

Currently, Deepl only allow one option: `TranslatorOptions::TIMEOUT`.
This one is used for both
- \CURLOPT_CONNECTTIMEOUT
- \CURLOPT_TIMEOUT_MS

But we might accept a CURLOPT_TIMEOUT_MS of 30s while we want a low CURLOPT_CONNECTTIMEOUT.
In general it doesn't make a lot of sens to have more than a few seconds for the connect timeout.

So it should be better to split both option
- `TranslatorOptions::CONNECT_TIMEOUT`
- `TranslatorOptions::EXEC_TIMEOUT`

To keep the old behavior, I kept the `TranslatorOptions::TIMEOUT` option which is used as a default value for both `CONNECT_TIMEOUT` and `EXEC_TIMEOUT`

Also, the doc was saying
```
timeout: the number of seconds used as connection timeout for each HTTP request retry. The default value is 10.0 (10 seconds).
```
So I changed it to `connect_timeout`. (Even if `timeout` will still work for the BC compatibility).

I'm open to any feedback :)