### PR TITLE
Allow to translate empty strings

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -578,16 +578,16 @@ class Translator
     {
         if (is_array($texts)) {
             foreach ($texts as $text) {
-                if (!is_string($text) || strlen($text) === 0) {
+                if (!is_string($text)) {
                     throw new DeepLException(
-                        'texts parameter must be a non-empty string or array of non-empty strings',
+                        'texts parameter must be a string or array of strings',
                     );
                 }
             }
         } else {
-            if (!is_string($texts) || strlen($texts) === 0) {
+            if (!is_string($texts)) {
                 throw new DeepLException(
-                    'texts parameter must be a non-empty string or array of non-empty strings',
+                    'texts parameter must be a string or array of strings',
                 );
             }
         }

--- a/tests/TranslateTextTest.php
+++ b/tests/TranslateTextTest.php
@@ -72,7 +72,7 @@ class TranslateTextTest extends DeepLTestBase
 
     public function invalidTextParameters(): array
     {
-        return [[''], [['']]];
+        return [[42], [[42]]];
     }
 
     /**
@@ -98,6 +98,14 @@ class TranslateTextTest extends DeepLTestBase
         $timeAfter = microtime(true);
         // Elapsed time should be at least 1 second
         $this->assertGreaterThan(1.0, $timeAfter - $timeBefore);
+    }
+
+    public function testEmptyText()
+    {
+        $this->needsRealServer();
+        $translator = $this->makeTranslator();
+
+        $this->assertEquals('', $translator->translateText('', null, 'de')->text);
     }
 
     public function testFormality()


### PR DESCRIPTION
Hi @JanEbbing 

Currently an exception is thrown when we try to translate an empty string.
This seems to be an unnecessary check because if I remove the check manually in my vendors, the API works fine.

When receiving multiple users inputs and if we want to translate for instance
```
['foo', 'bar', '', 'baz']
```
This seems unnecessary to ask us to
- Filter the `''` value
- Translate `[0 => 'foo', 1 => 'bar', 3 => 'baz']` (while the API call lose the initial keys)
- Receving the translation [0 => 'Tfoo', 1 => 'Tbar', 2 => 'Tbaz']
- Insert back the empty string in the right position to get [0 => 'Tfoo', 1 => 'Tbar', 2 => '', 3 => 'Tbaz']

While an API call with `['foo', 'bar', '', 'baz']` seems to works fine if the input validation is removed.