### PR TITLE
Add gitattributes files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.* export-ignore
+/tests/ export-ignore
+/*.md export-ignore
+/Dockerfile export-ignore
+/license_checker.sh export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
Hi @JanEbbing, 

I just discovered this repository didn't have `.gitattributes` file,

Entries with `export-ignore` allows to avoid downloading those file/folder when doing composer install.
Before:
<img width="228" alt="image" src="https://github.com/DeepLcom/deepl-php/assets/9052536/1c06cb4d-466c-40be-9658-835919460380">
After:
<img width="166" alt="image" src="https://github.com/DeepLcom/deepl-php/assets/9052536/2256bb7e-5cc7-4274-b1f0-056fbd883bed">
