### PR TITLE
Fix `JsonException: Malformed UTF-8 characters, possibly incorrectly encoded`

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -171,6 +171,12 @@ class Translator
         $this->checkStatusCode($response);
 
         list(, $content) = $response;
+
+        // Deepl API responses might have invalid UTF8 sequence
+        // @see https://github.com/DeepLcom/deepl-php/pull/43
+        mb_substitute_character(0xFFFD);
+        $content = mb_convert_encoding($content, 'UTF-8', 'UTF-8');
+
         try {
             $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
         } catch (JsonException $exception) {

--- a/tests/TranslateTextTest.php
+++ b/tests/TranslateTextTest.php
@@ -40,6 +40,20 @@ class TranslateTextTest extends DeepLTestBase
     /**
      * @dataProvider provideHttpClient
      */
+    public function testWithWeirdContent(?ClientInterface $httpClient)
+    {
+        $translator = $this->makeTranslator([TranslatorOptions::HTTP_CLIENT => $httpClient]);
+        $input = ['Portal<span></span>'];
+        $result = $translator->translateText($input, 'en', 'fr', [
+            TranslateTextOptions::TAG_HANDLING => 'xml',
+            TranslateTextOptions::IGNORE_TAGS => 'notranslate',
+        ]);
+        $this->assertInstanceOf(TextResult::class, $result);
+    }
+
+    /**
+     * @dataProvider provideHttpClient
+     */
     public function testLangCodeMixedCase(?ClientInterface $httpClient)
     {
         $translator = $this->makeTranslator([TranslatorOptions::HTTP_CLIENT => $httpClient]);

--- a/tests/TranslateTextTest.php
+++ b/tests/TranslateTextTest.php
@@ -43,7 +43,7 @@ class TranslateTextTest extends DeepLTestBase
     public function testWithWeirdContent(?ClientInterface $httpClient)
     {
         $translator = $this->makeTranslator([TranslatorOptions::HTTP_CLIENT => $httpClient]);
-        $input = ['Portal<span></span>'];
+        $input = 'Portal<span></span>';
         $result = $translator->translateText($input, 'en', 'fr', [
             TranslateTextOptions::TAG_HANDLING => 'xml',
             TranslateTextOptions::IGNORE_TAGS => 'notranslate',

--- a/tests/TranslateTextTest.php
+++ b/tests/TranslateTextTest.php
@@ -40,8 +40,9 @@ class TranslateTextTest extends DeepLTestBase
     /**
      * @dataProvider provideHttpClient
      */
-    public function testWithWeirdContent(?ClientInterface $httpClient)
+    public function testHandlingResponseWithInvalidUtf8(?ClientInterface $httpClient)
     {
+        $this->needsRealServer();
         $translator = $this->makeTranslator([TranslatorOptions::HTTP_CLIENT => $httpClient]);
         $input = 'Portal<span></span>';
         $result = $translator->translateText($input, 'en', 'fr', [


### PR DESCRIPTION
Hi @JanEbbing @daniel-jones-deepl,

We recently encountered an issue with text input which after deepl translation cannot be json_decoded by the library.
I create a reproducer of the issue. Notice this only occurs with the option
```
TranslateTextOptions::TAG_HANDLING => 'xml',
```

This is how is rendered the input in my IDE
<img width="199" alt="image" src="https://github.com/DeepLcom/deepl-php/assets/9052536/c7d7d8e2-9abe-4b41-ab96-b3f291f9b811">

The test added is failing with the error:
```
JsonException: Malformed UTF-8 characters, possibly incorrectly encoded
```
This is especially annoying because when translating a payload with 1000 texts, if one of them has such a character, the whole payload is failing and no text is translated (when 999 could have been).

Is something can be done:
- On deepl side ?
- On this library ?
- On my side ?

Thanks