### PR TITLE
Remove alpha label from context parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ using the following keys:
 -   `tag_handling`: type of tags to parse before translation, options are `'html'`
     and `'xml'`.
 -   `context`: specifies additional context to influence translations, that is not
-    translated itself. Note this is an **alpha feature**: it may be deprecated at
-    any time, or incur charges if it becomes generally available.
+    translated itself. Characters in the `context` parameter are not counted toward billing.
     See the [API documentation][api-docs-context-param] for more information and
     example usage.
 -   `glossary`: glossary ID of glossary to use for translation.

--- a/src/TranslateTextOptions.php
+++ b/src/TranslateTextOptions.php
@@ -37,8 +37,7 @@ class TranslateTextOptions
     public const FORMALITY = 'formality';
 
     /** Specifies additional context to influence translations, that is not
-     * translated itself. Note this is an **alpha feature**: it may be deprecated at
-     * any time, or incur charges if it becomes generally available.
+     * translated itself. Characters in the context parameter are not counted toward billing.
      * See the API documentation for more information and example usage.
      */
     public const CONTEXT = 'context';


### PR DESCRIPTION
The `context` parameter is no longer an alpha feature and is generally available. This PR updates the README to reflect this change.