### PR TITLE
Avoid BC break in TextResult

### DIFF
--- a/src/TextResult.php
+++ b/src/TextResult.php
@@ -28,7 +28,7 @@ class TextResult
     public $billedCharacters;
 
     /**
-     * @var string Model type used for the translation.
+     * @var string|null Model type used for the translation.
      * @see TranslateTextOptions::MODEL_TYPE
      */
     public $modelTypeUsed;
@@ -40,7 +40,7 @@ class TextResult
         string $text,
         string $detectedSourceLang,
         int $billedCharacters,
-        ?string $modelTypeUsed
+        ?string $modelTypeUsed = null
     ) {
         $this->text = $text;
         $this->detectedSourceLang = LanguageCode::standardizeLanguageCode($detectedSourceLang);


### PR DESCRIPTION
Hi @JanEbbing 

The commit https://github.com/DeepLcom/deepl-php/commit/04403a0760e47edbc071ea765c5167688efcf870 introduce a BC break by changing the signature of this class, but was tagged as a minor.

The model type used should have a default value to avoid BC break, especially when null is allowed.