### PR TITLE
PHP 8.4 php_uname ValueError

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -763,7 +763,7 @@ class Translator
         $libraryInfoStr = "deepl-php/$libraryVersion";
         try {
             if ($sendPlatformInfo) {
-                $platformStr = php_uname('s r v m');
+                $platformStr = php_uname('s') . ' ' . php_uname('r') . ' ' . php_uname('v') . php_uname('m');
                 $phpVersion = phpversion();
                 $libraryInfoStr .= " ($platformStr) php/$phpVersion";
                 $curlVer = curl_version()['version'];


### PR DESCRIPTION
This is a quick fix for the ValueError that occurs on PHP 8.4

See: https://github.com/DeepLcom/deepl-php/issues/54 