### PR TITLE
fix: Add initialize property `$params`

### DIFF
--- a/src/DeepLClient.php
+++ b/src/DeepLClient.php
@@ -311,6 +311,9 @@ class DeepLClient extends Translator
         ?string $style = null,
         ?string $tone = null
     ): array {
+
+        $params = [];
+
         if ($targetLang !== null) {
             $targetLang = LanguageCode::standardizeLanguageCode($targetLang);
             if ($targetLang === 'en') {


### PR DESCRIPTION
### Description
- Initialize `$params` array before conditional assignments to prevent undefined variable error.